### PR TITLE
Added  toybox.py support

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -5,7 +5,22 @@
 
 <br>
 
-## Steps
+#### Using toybox.py
+
+You can add it to your **Playdate** project by installing [**toybox.py**](https://toyboxpy.io), going to your project folder in a Terminal window and typing:
+
+```console
+toybox add Whitebrim/AnimatedSprite
+toybox update
+```
+
+Then, if your code is in the `source` folder, just import the following:
+
+```lua
+import '../toyboxes/toyboxes.lua'
+```
+
+#### Manually
 
 1.  Download the [`AnimatedSprite.lua`][Library] file.
 
@@ -30,8 +45,10 @@
     ```
     
     <br>
-    
-5.  If missing, add the following function <br>
+
+### Update your code
+
+If missing, add the following function <br>
     to your `playdate.update()` function:
     
     ```lua

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
-# AnimatedSprite   [![Badge License]][License]
+# AnimatedSprite
+[![Badge License]][License] [![Toybox Compatible](https://img.shields.io/badge/toybox.py-compatible-brightgreen?style=for-the-badge)](https://toyboxpy.io) [![Latest Version](https://img.shields.io/github/v/tag/Whitebrim/AnimatedSprite?style=for-the-badge)](https://github.com/Whitebrim/AnimatedSprite/tags)
 
 Animated sprites library for the **[PlayDate]**.
 


### PR DESCRIPTION
This doesn't change much since the library was already in the right format but it adds instructions on how it can be used with [toybox.py](https://toyboxpy.io) for Playdate.

The only other thing required is to tag releases using a [semver](https://semver.org) version so that users can easily update when a new version is posted.