### PR TITLE
Added support for Luacheck

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,5 @@
+stds.animatedsprite = require "luacheck/Luacheck"
+
+std = "lua54+playdate+animatedsprite"
+
+operators = {"+=", "-=", "*=", "/="}

--- a/luacheck/Luacheck.lua
+++ b/luacheck/Luacheck.lua
@@ -1,0 +1,43 @@
+-- Globals provided by AnimatedSprite.
+--
+-- This file can be used by toyboypy (https://toyboxpy.io) to import into a project's luacheck config.
+--
+-- Just add this to your project's .luacheckrc:
+--    require "toyboxes/luacheck" (stds, files)
+--
+-- and then add 'toyboxes' to your std:
+--    std = "lua54+playdate+toyboxes"
+
+return {
+    globals = {
+        AnimatedSprite = {
+            fields = {
+                super = {
+                    fields = {
+                        className = {},
+                        init = {}
+                    }
+                },
+                className = {},
+                init = {},
+                new = {},
+                playAnimation = {},
+                pauseAnimation = {},
+                toggleAnimation = {},
+                stopAnimation = {},
+                loadStates = {},
+                getCurrentFrameIndex = {},
+                getLocalStates = {},
+                copyLocalStates = {},
+                setStates = {},
+                addState = {},
+                changeState = {},
+                forceNextAnimation = {},
+                setDefaultState = {},
+                printAllStates = {},
+                updateAnimation = {},
+                update = {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
This lists the globals defined in AnimatedSprite.lua in a way that Luacheck can use for the project itself but also when the project is used a toybox (will be supported in toybox.py v1.1).