### PR TITLE
Updated installation doc for toybox v1.1.0

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -36,7 +36,7 @@
 1.  You can install this library to your Playdate project via [**toybox.py**](https://toyboxpy.io), by going to your project folder in a Terminal window and typing:
 
     ```console
-    toybox add Whitebrim/AnimatedSprite
+    toybox add AnimatedSprite
     toybox update
     ```
 


### PR DESCRIPTION
This repo is now in the new toy store which toybox v1.1.0 supports. You can now refer it simply by name and it will point to this GitHub repo automatically.