### PR TITLE
Add resume function to play the current animation without resetting

### DIFF
--- a/AnimatedSprite.lua
+++ b/AnimatedSprite.lua
@@ -122,6 +122,11 @@ function AnimatedSprite:pauseAnimation()
 	self._enabled = false
 end
 
+---Play the animation without resetting
+function AnimatedSprite:resumeAnimation()
+	self._enabled = true
+end
+
 ---Play/Pause animation based on current state
 function AnimatedSprite:toggleAnimation()
 	if (self._enabled) then


### PR DESCRIPTION
I found that sometimes I would want to unpause the animation without resetting it (e.g. climbing a ladder and pausing the animation when the player stops climbing and resuming when they continue).

```lua
if self.currentState == "climb" then
   ...
   if pd.buttonIsPressed(pd.kButtonUp) then
      self.yVelocity = -self.climbVelocity
      self:resumeAnimation()
   else
      self:pauseAnimation()
   end
   ...
end
```

In this situation, :playAnimation() would continuously reset the animation to the first frame, while :resumeAnimation() would allow the animation to continue despite being repeatedly called.  