### PR TITLE
Prevent crash when resuming a stopped animation

### DIFF
--- a/AnimatedSprite.lua
+++ b/AnimatedSprite.lua
@@ -127,7 +127,9 @@ end
 
 ---Play the animation without resetting
 function AnimatedSprite:resumeAnimation()
-	self._enabled = true
+	if self.currentState ~= nil then
+		self._enabled = true
+	end
 end
 
 ---Play/Pause animation based on current state


### PR DESCRIPTION
If you try to resume a stopped animation, self._enabled gets enabled, but the current state is nil

so the app will crash at updateAnimation()

This makes sure that self._enabled is set to true only if the current animation is not nil